### PR TITLE
Polish the UI

### DIFF
--- a/com.github.unrud.VideoDownloader.json
+++ b/com.github.unrud.VideoDownloader.json
@@ -113,6 +113,23 @@
             ]
         },
         {
+            "name": "libhandy",
+            "buildsystem": "meson",
+            "builddir": true,
+            "config-opts": [
+                "-Dexamples=false",
+                "-Dglade_catalog=disabled",
+                "-Dtests=false",
+                "-Dvapi=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/libhandy.git"
+                }
+            ]
+        },
+        {
             "name" : "video-downloader",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@
 import gettext
 import sys
 
-from gi.repository import GLib, Gtk, Gio
+from gi.repository import GLib, Gtk, Gio, Handy
 
 from video_downloader.authentication_dialog import LoginDialog, PasswordDialog
 from video_downloader.model import Handler, Model
@@ -51,6 +51,10 @@ class Application(Gtk.Application, Handler):
                       self._settings.set_string('mode', x))
         bind_property(self.model, 'resolution', func_a_to_b=lambda x:
                       self._settings.set_uint('resolution', x))
+
+    def do_startup(self):
+        Gtk.Application.do_startup(self)
+        Handy.init()
 
     def do_activate(self):
         for name in self.model.actions.list_actions():

--- a/src/window.py
+++ b/src/window.py
@@ -39,7 +39,8 @@ class Window(Handy.ApplicationWindow):
     resolution_wdg = Gtk.Template.Child()
     main_stack_wdg = Gtk.Template.Child()
     audio_video_stack_wdg = Gtk.Template.Child()
-    download_wdg = Gtk.Template.Child()
+    audio_download_wdg = Gtk.Template.Child()
+    video_download_wdg = Gtk.Template.Child()
     error_back_wdg = Gtk.Template.Child()
     success_back_wdg = Gtk.Template.Child()
     download_cancel_wdg = Gtk.Template.Child()
@@ -66,7 +67,6 @@ class Window(Handy.ApplicationWindow):
         bind_property(
             self.model, 'state', self.main_stack_wdg, 'visible-child-name',
             lambda s: {s: s, 'cancel': 'download'}[s])
-        bind_property(self.model, 'state', func_a_to_b=self._update_header)
         bind_property(self.model, 'mode', self.audio_video_stack_wdg,
                       'visible-child-name', bi=True)
         bind_property(self.main_stack_wdg, 'visible-child-name',
@@ -182,17 +182,15 @@ class Window(Handy.ApplicationWindow):
             return True
         return False
 
-    def _update_header(self, state):
-        self.download_wdg.set_visible(state == 'start')
-
     def _update_focus_and_default(self, _):
         state = self.main_stack_wdg.get_visible_child_name()
         mode = self.audio_video_stack_wdg.get_visible_child_name()
         if state == 'start':
-            self.download_wdg.grab_default()
             if mode == 'audio':
+                self.audio_download_wdg.grab_default()
                 self.audio_url_wdg.grab_focus()
             elif mode == 'video':
+                self.video_download_wdg.grab_default()
                 self.video_url_wdg.grab_focus()
             else:
                 assert False

--- a/src/window.py
+++ b/src/window.py
@@ -39,11 +39,10 @@ class Window(Handy.ApplicationWindow):
     resolution_wdg = Gtk.Template.Child()
     main_stack_wdg = Gtk.Template.Child()
     audio_video_stack_wdg = Gtk.Template.Child()
-    audio_video_switcher_wdg = Gtk.Template.Child()
     download_wdg = Gtk.Template.Child()
-    back_wdg = Gtk.Template.Child()
-    cancel_wdg = Gtk.Template.Child()
-    title_wdg = Gtk.Template.Child()
+    error_back_wdg = Gtk.Template.Child()
+    success_back_wdg = Gtk.Template.Child()
+    download_cancel_wdg = Gtk.Template.Child()
     success_msg_wdg = Gtk.Template.Child()
     download_title_wdg = Gtk.Template.Child()
     download_progress_wdg = Gtk.Template.Child()
@@ -184,11 +183,7 @@ class Window(Handy.ApplicationWindow):
         return False
 
     def _update_header(self, state):
-        self.audio_video_switcher_wdg.set_visible(state == 'start')
         self.download_wdg.set_visible(state == 'start')
-        self.back_wdg.set_visible(state in ['success', 'error'])
-        self.cancel_wdg.set_visible(state in ['download', 'cancel'])
-        self.title_wdg.set_visible(state != 'start')
 
     def _update_focus_and_default(self, _):
         state = self.main_stack_wdg.get_visible_child_name()
@@ -201,9 +196,11 @@ class Window(Handy.ApplicationWindow):
                 self.video_url_wdg.grab_focus()
             else:
                 assert False
-        elif state in ['download', 'cancel']:
-            self.cancel_wdg.grab_focus()
-        elif state in ['success', 'error']:
-            self.back_wdg.grab_focus()
+        elif state == 'download':
+            self.download_cancel_wdg.grab_focus()
+        elif state == 'error':
+            self.error_back_wdg.grab_focus()
+        elif state == 'success':
+            self.success_back_wdg.grab_focus()
         else:
             assert False

--- a/src/window.py
+++ b/src/window.py
@@ -20,7 +20,7 @@ import locale
 import math
 import os
 
-from gi.repository import GLib, Gtk, GdkPixbuf, GObject
+from gi.repository import GLib, Gtk, GdkPixbuf, GObject, Handy
 
 from video_downloader.util import bind_property
 
@@ -30,7 +30,7 @@ N_ = gettext.gettext
 
 
 @Gtk.Template(resource_path='/com/github/unrud/VideoDownloader/window.ui')
-class Window(Gtk.ApplicationWindow):
+class Window(Handy.ApplicationWindow):
     __gtype_name__ = 'VideoDownloaderWindow'
     error_buffer = Gtk.Template.Child()
     resolutions_store = Gtk.Template.Child()

--- a/src/window.ui
+++ b/src/window.ui
@@ -31,8 +31,9 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="show_close_button">True</property>
+                <property name="centering_policy">strict</property>
                 <child type="title">
-                  <object class="GtkStackSwitcher">
+                  <object class="HdyViewSwitcher">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="stack">audio_video_stack_wdg</property>

--- a/src/window.ui
+++ b/src/window.ui
@@ -47,29 +47,52 @@
                 <property name="can_focus">False</property>
                 <property name="transition_type">crossfade</property>
                 <child>
-                  <object class="GtkBox" id="audio_page">
+                  <object class="HdyClamp">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">18</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">18</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="spacing">12</property>
+                        <property name="border_width">18</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">18</property>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">URL</property>
-                            <property name="xalign">1</property>
-                            <accessibility>
-                              <relation type="label-for" target="audio_url_wdg"/>
-                            </accessibility>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">URL</property>
+                                <property name="xalign">1</property>
+                                <accessibility>
+                                  <relation type="label-for" target="audio_url_wdg"/>
+                                </accessibility>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="audio_url_wdg">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="activates_default">True</property>
+                                <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -78,37 +101,19 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkEntry" id="audio_url_wdg">
+                          <object class="GtkButton" id="audio_download_wdg">
+                            <property name="label" translatable="yes">Download</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="activates_default">True</property>
-                            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
+                            <property name="can_default">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">center</property>
+                            <property name="action_name">app.download</property>
+                            <style>
+                              <class name="suggested-action"/>
+                            </style>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="audio_download_wdg">
-                        <property name="label" translatable="yes">Download</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="can_default">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="halign">center</property>
-                        <property name="action_name">app.download</property>
-                        <style>
-                          <class name="suggested-action"/>
-                        </style>
                       </object>
                     </child>
                   </object>
@@ -119,119 +124,124 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="video_page">
+                  <object class="HdyClamp" id="video_page">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">18</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">18</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="spacing">12</property>
+                        <property name="border_width">18</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">18</property>
                         <child>
-                          <object class="GtkLabel" id="video_url_label">
+                          <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">URL</property>
-                            <property name="xalign">1</property>
-                            <accessibility>
-                              <relation type="label-for" target="video_url_wdg"/>
-                            </accessibility>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="video_url_wdg">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="activates_default">True</property>
-                            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">12</property>
-                        <child>
-                          <object class="GtkLabel" id="resolution_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Resolution</property>
-                            <property name="xalign">1</property>
-                            <accessibility>
-                              <relation type="label-for" target="resolution_wdg"/>
-                            </accessibility>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBox" id="resolution_wdg">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="model">resolutions_store</property>
-                            <property name="active">0</property>
-                            <property name="id_column">0</property>
+                            <property name="spacing">12</property>
                             <child>
-                              <object class="GtkCellRendererText"/>
-                              <attributes>
-                                <attribute name="text">1</attribute>
-                              </attributes>
+                              <object class="GtkLabel" id="video_url_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">URL</property>
+                                <property name="xalign">1</property>
+                                <accessibility>
+                                  <relation type="label-for" target="video_url_wdg"/>
+                                </accessibility>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="video_url_wdg">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="activates_default">True</property>
+                                <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel" id="resolution_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Resolution</property>
+                                <property name="xalign">1</property>
+                                <accessibility>
+                                  <relation type="label-for" target="resolution_wdg"/>
+                                </accessibility>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="resolution_wdg">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">resolutions_store</property>
+                                <property name="active">0</property>
+                                <property name="id_column">0</property>
+                                <child>
+                                  <object class="GtkCellRendererText"/>
+                                  <attributes>
+                                    <attribute name="text">1</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="video_download_wdg">
-                        <property name="label" translatable="yes">Download</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="can_default">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="halign">center</property>
-                        <property name="action_name">app.download</property>
-                        <style>
-                          <class name="suggested-action"/>
-                        </style>
+                        <child>
+                          <object class="GtkButton" id="video_download_wdg">
+                            <property name="label" translatable="yes">Download</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="can_default">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">center</property>
+                            <property name="action_name">app.download</property>
+                            <style>
+                              <class name="suggested-action"/>
+                            </style>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/src/window.ui
+++ b/src/window.ui
@@ -45,10 +45,12 @@
               <object class="GtkStack" id="audio_video_stack_wdg">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="vexpand">True</property>
                 <property name="transition_type">crossfade</property>
                 <child>
                   <object class="HdyClamp">
                     <property name="visible">True</property>
+                    <property name="valign">center</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -126,6 +128,7 @@
                 <child>
                   <object class="HdyClamp" id="video_page">
                     <property name="visible">True</property>
+                    <property name="valign">center</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>

--- a/src/window.ui
+++ b/src/window.ui
@@ -16,85 +16,27 @@
   <template class="VideoDownloaderWindow" parent="HdyApplicationWindow">
     <property name="can_focus">False</property>
     <property name="default_width">600</property>
+    <property name="title" translatable="yes">Video Downloader</property>
     <child>
-      <object class="GtkBox">
+      <object class="GtkStack" id="main_stack_wdg">
         <property name="visible">True</property>
-        <property name="orientation">vertical</property>
+        <property name="can_focus">False</property>
+        <property name="transition_type">slide-left-right</property>
         <child>
-          <object class="HdyHeaderBar" id="header_bar">
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="show_close_button">True</property>
-            <child type="title">
-              <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="HdyHeaderBar">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="hexpand">True</property>
-                <child type="center">
-                  <object class="GtkBox">
+                <property name="show_close_button">True</property>
+                <child type="title">
+                  <object class="GtkStackSwitcher">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkStackSwitcher" id="audio_video_switcher_wdg">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="stack">audio_video_stack_wdg</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="title_wdg">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Video Downloader</property>
-                        <style>
-                          <class name="title"/>
-                        </style>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
+                    <property name="stack">audio_video_stack_wdg</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="back_wdg">
-                    <property name="label" translatable="yes">Back</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="action_name">app.back</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="cancel_wdg">
-                    <property name="label" translatable="yes">Cancel</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="action_name">app.cancel</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="download_wdg">
@@ -109,21 +51,11 @@
                     </style>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
                     <property name="pack_type">end</property>
-                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkStack" id="main_stack_wdg">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="transition_type">slide-left-right</property>
             <child>
               <object class="GtkStack" id="audio_video_stack_wdg">
                 <property name="visible">True</property>
@@ -296,9 +228,32 @@
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="name">start</property>
-              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">start</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="HdyHeaderBar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="show_close_button">True</property>
+                <property name="title" bind-source="VideoDownloaderWindow" bind-property="title" bind-flags="sync-create"/>
+                <child>
+                  <object class="GtkButton" id="download_cancel_wdg">
+                    <property name="label" translatable="yes">Cancel</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="action_name">app.cancel</property>
+                  </object>
+                </child>
+              </object>
             </child>
             <child>
               <object class="GtkBox" id="download_page">
@@ -383,10 +338,33 @@
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="name">download</property>
-                <property name="position">1</property>
-              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">download</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="HdyHeaderBar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="show_close_button">True</property>
+                <property name="title" bind-source="VideoDownloaderWindow" bind-property="title" bind-flags="sync-create"/>
+                <child>
+                  <object class="GtkButton" id="error_back_wdg">
+                    <property name="label" translatable="yes">Back</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="action_name">app.back</property>
+                  </object>
+                </child>
+              </object>
             </child>
             <child>
               <object class="GtkBox" id="error_page">
@@ -495,10 +473,33 @@
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="name">error</property>
-                <property name="position">2</property>
-              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">error</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="HdyHeaderBar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="show_close_button">True</property>
+                <property name="title" bind-source="VideoDownloaderWindow" bind-property="title" bind-flags="sync-create"/>
+                <child>
+                  <object class="GtkButton" id="success_back_wdg">
+                    <property name="label" translatable="yes">Back</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="action_name">app.back</property>
+                  </object>
+                </child>
+              </object>
             </child>
             <child>
               <object class="GtkBox" id="success_page">
@@ -565,12 +566,12 @@
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="name">success</property>
-                <property name="position">3</property>
-              </packing>
             </child>
           </object>
+          <packing>
+            <property name="name">success</property>
+            <property name="position">3</property>
+          </packing>
         </child>
       </object>
     </child>

--- a/src/window.ui
+++ b/src/window.ui
@@ -20,25 +20,47 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="orientation">vertical</property>
-    <child>
-      <object class="HdyHeaderBar" id="header_bar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="show_close_button">True</property>
-        <child type="title">
-          <object class="GtkBox">
+        <child>
+          <object class="HdyHeaderBar" id="header_bar">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="hexpand">True</property>
-            <child type="center">
+            <property name="show_close_button">True</property>
+            <child type="title">
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkStackSwitcher" id="audio_video_switcher_wdg">
+                <property name="hexpand">True</property>
+                <child type="center">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="stack">audio_video_stack_wdg</property>
+                    <child>
+                      <object class="GtkStackSwitcher" id="audio_video_switcher_wdg">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="stack">audio_video_stack_wdg</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="title_wdg">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Video Downloader</property>
+                        <style>
+                          <class name="title"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -47,13 +69,494 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="title_wdg">
+                  <object class="GtkButton" id="back_wdg">
+                    <property name="label" translatable="yes">Back</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="action_name">app.back</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="cancel_wdg">
+                    <property name="label" translatable="yes">Cancel</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="action_name">app.cancel</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="download_wdg">
+                    <property name="label" translatable="yes">Download</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="action_name">app.download</property>
+                    <style>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStack" id="main_stack_wdg">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="transition_type">slide-left-right</property>
+            <child>
+              <object class="GtkStack" id="audio_video_stack_wdg">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="transition_type">crossfade</property>
+                <child>
+                  <object class="GtkBox" id="audio_page">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Video Downloader</property>
-                    <style>
-                      <class name="title"/>
-                    </style>
+                    <property name="border_width">18</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">18</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">URL</property>
+                            <property name="xalign">1</property>
+                            <accessibility>
+                              <relation type="label-for" target="audio_url_wdg"/>
+                            </accessibility>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="audio_url_wdg">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="activates_default">True</property>
+                            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">audio</property>
+                    <property name="title" translatable="yes">Audio</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="video_page">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="border_width">18</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">18</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkLabel" id="video_url_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">URL</property>
+                            <property name="xalign">1</property>
+                            <accessibility>
+                              <relation type="label-for" target="video_url_wdg"/>
+                            </accessibility>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="video_url_wdg">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="activates_default">True</property>
+                            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkLabel" id="resolution_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Resolution</property>
+                            <property name="xalign">1</property>
+                            <accessibility>
+                              <relation type="label-for" target="resolution_wdg"/>
+                            </accessibility>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="resolution_wdg">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="model">resolutions_store</property>
+                            <property name="active">0</property>
+                            <property name="id_column">0</property>
+                            <child>
+                              <object class="GtkCellRendererText"/>
+                              <attributes>
+                                <attribute name="text">1</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">video</property>
+                    <property name="title" translatable="yes">Video</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">start</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="download_page">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">18</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">18</property>
+                <child>
+                  <object class="GtkLabel" id="download_title_wdg">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label">Downloading: XXX</property>
+                    <property name="ellipsize">end</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkStack" id="download_images_wdg">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="transition_type">slide-up-down</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkProgressBar" id="download_progress_wdg">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="download_info_wdg">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label">Info XXX</property>
+                        <property name="xalign">0</property>
+                        <accessibility>
+                          <relation type="label-for" target="download_progress_wdg"/>
+                        </accessibility>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">download</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="error_page">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">18</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">dialog-error</property>
+                        <property name="icon_size">6</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Download failed</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkExpander" id="error_details_expander_wdg">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Details</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRevealer" id="error_details_revealer_wdg">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="transition_type">crossfade</property>
+                    <property name="reveal_child">True</property>
+                    <child>
+                      <object class="GtkScrolledWindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="hscrollbar_policy">never</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkTextView">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="editable">False</property>
+                            <property name="wrap_mode">word-char</property>
+                            <property name="buffer">error_buffer</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <accessibility>
+                      <relation type="embedded-by" target="error_details_expander_wdg"/>
+                    </accessibility>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">error</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="success_page">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">18</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkImage" id="success_symbol">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">start</property>
+                        <property name="icon_name">dialog-information</property>
+                        <property name="icon_size">6</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="success_title">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Download finished</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="success_msg_wdg">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label">Download saved in XXX</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">word-char</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -63,515 +566,12 @@
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="back_wdg">
-                <property name="label" translatable="yes">Back</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="action_name">app.back</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="cancel_wdg">
-                <property name="label" translatable="yes">Cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="action_name">app.cancel</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="download_wdg">
-                <property name="label" translatable="yes">Download</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="action_name">app.download</property>
-                <style>
-                  <class name="suggested-action"/>
-                </style>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
+                <property name="name">success</property>
                 <property name="position">3</property>
               </packing>
             </child>
           </object>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkStack" id="main_stack_wdg">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="transition_type">slide-left-right</property>
-        <child>
-          <object class="GtkStack" id="audio_video_stack_wdg">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="transition_type">crossfade</property>
-            <child>
-              <object class="GtkBox" id="audio_page">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">18</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">18</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">URL</property>
-                        <property name="xalign">1</property>
-                        <accessibility>
-                          <relation type="label-for" target="audio_url_wdg"/>
-                        </accessibility>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="audio_url_wdg">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="activates_default">True</property>
-                        <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="name">audio</property>
-                <property name="title" translatable="yes">Audio</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="video_page">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">18</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">18</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="video_url_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">URL</property>
-                        <property name="xalign">1</property>
-                        <accessibility>
-                          <relation type="label-for" target="video_url_wdg"/>
-                        </accessibility>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="video_url_wdg">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="activates_default">True</property>
-                        <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="resolution_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Resolution</property>
-                        <property name="xalign">1</property>
-                        <accessibility>
-                          <relation type="label-for" target="resolution_wdg"/>
-                        </accessibility>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkComboBox" id="resolution_wdg">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="model">resolutions_store</property>
-                        <property name="active">0</property>
-                        <property name="id_column">0</property>
-                        <child>
-                          <object class="GtkCellRendererText"/>
-                          <attributes>
-                            <attribute name="text">1</attribute>
-                          </attributes>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="name">video</property>
-                <property name="title" translatable="yes">Video</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="name">start</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="download_page">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">18</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">18</property>
-            <child>
-              <object class="GtkLabel" id="download_title_wdg">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label">Downloading: XXX</property>
-                <property name="ellipsize">end</property>
-                <property name="xalign">0</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkStack" id="download_images_wdg">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="transition_type">slide-up-down</property>
-                <child>
-                  <placeholder/>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkProgressBar" id="download_progress_wdg">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="download_info_wdg">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label">Info XXX</property>
-                    <property name="xalign">0</property>
-                    <accessibility>
-                      <relation type="label-for" target="download_progress_wdg"/>
-                    </accessibility>
-                    <style>
-                      <class name="dim-label"/>
-                    </style>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="name">download</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="error_page">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">18</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">12</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">dialog-error</property>
-                    <property name="icon_size">6</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Download failed</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkExpander" id="error_details_expander_wdg">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <child>
-                  <placeholder/>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Details</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkRevealer" id="error_details_revealer_wdg">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="transition_type">crossfade</property>
-                <property name="reveal_child">True</property>
-                <child>
-                  <object class="GtkScrolledWindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="hscrollbar_policy">never</property>
-                    <property name="shadow_type">in</property>
-                    <child>
-                      <object class="GtkTextView">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="editable">False</property>
-                        <property name="wrap_mode">word-char</property>
-                        <property name="buffer">error_buffer</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <accessibility>
-                  <relation type="embedded-by" target="error_details_expander_wdg"/>
-                </accessibility>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="name">error</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="success_page">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">18</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">12</property>
-                <child>
-                  <object class="GtkImage" id="success_symbol">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="valign">start</property>
-                    <property name="icon_name">dialog-information</property>
-                    <property name="icon_size">6</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="success_title">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Download finished</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="success_msg_wdg">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label">Download saved in XXX</property>
-                <property name="wrap">True</property>
-                <property name="wrap_mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="name">success</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-      </object>
-    </child>
       </object>
     </child>
   </template>

--- a/src/window.ui
+++ b/src/window.ui
@@ -115,6 +115,7 @@
                   <packing>
                     <property name="name">audio</property>
                     <property name="title" translatable="yes">Audio</property>
+                    <property name="icon-name">audio-x-generic-symbolic</property>
                   </packing>
                 </child>
                 <child>
@@ -237,6 +238,7 @@
                   <packing>
                     <property name="name">video</property>
                     <property name="title" translatable="yes">Video</property>
+                    <property name="icon-name">video-x-generic-symbolic</property>
                     <property name="position">1</property>
                   </packing>
                 </child>

--- a/src/window.ui
+++ b/src/window.ui
@@ -13,11 +13,15 @@
       <column type="gchararray"/>
     </columns>
   </object>
-  <template class="VideoDownloaderWindow" parent="GtkApplicationWindow">
+  <template class="VideoDownloaderWindow" parent="HdyApplicationWindow">
     <property name="can_focus">False</property>
     <property name="default_width">600</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar" id="header_bar">
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="orientation">vertical</property>
+    <child>
+      <object class="HdyHeaderBar" id="header_bar">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="show_close_button">True</property>
@@ -566,6 +570,8 @@
             <property name="position">3</property>
           </packing>
         </child>
+      </object>
+    </child>
       </object>
     </child>
   </template>

--- a/src/window.ui
+++ b/src/window.ui
@@ -38,22 +38,6 @@
                     <property name="stack">audio_video_stack_wdg</property>
                   </object>
                 </child>
-                <child>
-                  <object class="GtkButton" id="download_wdg">
-                    <property name="label" translatable="yes">Download</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="action_name">app.download</property>
-                    <style>
-                      <class name="suggested-action"/>
-                    </style>
-                  </object>
-                  <packing>
-                    <property name="pack_type">end</property>
-                  </packing>
-                </child>
               </object>
             </child>
             <child>
@@ -111,6 +95,20 @@
                         <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="audio_download_wdg">
+                        <property name="label" translatable="yes">Download</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="halign">center</property>
+                        <property name="action_name">app.download</property>
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
+                      </object>
                     </child>
                   </object>
                   <packing>
@@ -219,6 +217,20 @@
                         <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="video_download_wdg">
+                        <property name="label" translatable="yes">Download</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="halign">center</property>
+                        <property name="action_name">app.download</property>
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
+                      </object>
                     </child>
                   </object>
                   <packing>

--- a/src/window.ui
+++ b/src/window.ui
@@ -16,6 +16,105 @@
   <template class="VideoDownloaderWindow" parent="GtkApplicationWindow">
     <property name="can_focus">False</property>
     <property name="default_width">600</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="header_bar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="show_close_button">True</property>
+        <child type="title">
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <child type="center">
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkStackSwitcher" id="audio_video_switcher_wdg">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="stack">audio_video_stack_wdg</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="title_wdg">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Video Downloader</property>
+                    <style>
+                      <class name="title"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="back_wdg">
+                <property name="label" translatable="yes">Back</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">app.back</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="cancel_wdg">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">app.cancel</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="download_wdg">
+                <property name="label" translatable="yes">Download</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">app.download</property>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
     <child>
       <object class="GtkStack" id="main_stack_wdg">
         <property name="visible">True</property>
@@ -466,105 +565,6 @@
             <property name="name">success</property>
             <property name="position">3</property>
           </packing>
-        </child>
-      </object>
-    </child>
-    <child type="titlebar">
-      <object class="GtkHeaderBar" id="header_bar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="show_close_button">True</property>
-        <child type="title">
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="hexpand">True</property>
-            <child type="center">
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkStackSwitcher" id="audio_video_switcher_wdg">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="stack">audio_video_stack_wdg</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="title_wdg">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Video Downloader</property>
-                    <style>
-                      <class name="title"/>
-                    </style>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="back_wdg">
-                <property name="label" translatable="yes">Back</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="action_name">app.back</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="cancel_wdg">
-                <property name="label" translatable="yes">Cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="action_name">app.cancel</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="download_wdg">
-                <property name="label" translatable="yes">Download</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="action_name">app.download</property>
-                <style>
-                  <class name="suggested-action"/>
-                </style>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-          </object>
         </child>
       </object>
     </child>


### PR DESCRIPTION
This modernizes the UI a bit by using some features from libhandy.

Changes:
- isolate each view and give them their own header bar
- use `HdyApplicationWindow` to have cool looking rounded corners and easy animations
- use a `HdyViewSwitcher` instead of a `GtkStackSwitcher`
- move the Download button in the page to have a fully top-to-bottom flow
- vertically center the Audio and Video pages
- clamp the Audio and Video pages horizontally
- animate the header bars and not only the content

![Capture d’écran de 2020-08-12 22-23-00](https://user-images.githubusercontent.com/2536339/90064261-cc85cc00-dcea-11ea-97eb-3a8f33015754.png)

![Capture d’écran de 2020-08-12 22-32-03](https://user-images.githubusercontent.com/2536339/90064867-add40500-dceb-11ea-89ed-ba01ef8f0ffa.png)

If you like the changes, I have a few more ideas after that to further polish the UI.
