### PR TITLE
Provide a more complete guide to changing download folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In the following example, the download location is being changed to `~/Videos/Vi
 ```
 flatpak run --command=gsettings com.github.unrud.VideoDownloader set com.github.unrud.VideoDownloader download-folder 'xdg-videos/VideoDownloader'
 ```
-Remember to also give the flatpak the necessary filesystem permissions. This can be done through the command-line or through _Flatseal_.
+Remember to also give the flatpak the necessary filesystem permissions. This can be done through the command-line or through _Flatseal_.  If you used `xdg-videos/VideoDownloader` as the download folder in the previous command, remember to use that in the following command as well. Using `~/Videos/VideoDownloader` may cause an error.
 ```
 flatpak override com.github.unrud.VideoDownloader --filesystem=xdg-videos/VideoDownloader:create
 ```

--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ Paths can either be absolute or start with `~`, `xdg-desktop`, `xdg-download`,
 The default is `xdg-download/VideoDownloader`.
 
 #### Flatpak
-
+In the following example, the download location is being changed to `~/Videos/VideoDownloader` or `xdg-videos/VideoDownloader`.
 ```
-flatpak run --command=gsettings com.github.unrud.VideoDownloader set com.github.unrud.VideoDownloader download-folder '~/VideoDownloader'
+flatpak run --command=gsettings com.github.unrud.VideoDownloader set com.github.unrud.VideoDownloader download-folder 'xdg-videos/VideoDownloader'
 ```
+Remember to also give the flatpak the necessary filesystem permissions. This can be done through the command-line or through _Flatseal_.
+```
+flatpak override com.github.unrud.VideoDownloader --filesystem=xdg-videos/VideoDownloader:create
+```
+`:create` tells flatpak to make a new folder called `VideoDownloader` in `~/Videos` if it doesn't already exist.
 
 #### Snap
 


### PR DESCRIPTION
The README doesn't include any details on how to give the flatpak the necessary filesystem access when changing the default download folder. This results in an error as mentioned in #82.