### PR TITLE
Minor UI changes

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -559,6 +559,9 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                         <property name="halign">center</property>
                         <property name="label">Info XXX</property>
                         <property name="xalign">0</property>
+                        <accessibility>
+                          <relation type="label-for" target="download_progress_wdg"/>
+                        </accessibility>
                         <style>
                           <class name="dim-label"/>
                         </style>

--- a/src/window.ui
+++ b/src/window.ui
@@ -481,7 +481,7 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                 <property name="vexpand">True</property>
                 <property name="border-width">18</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">18</property>
+                <property name="spacing">30</property>
                 <child>
                   <object class="GtkLabel" id="download_title_wdg">
                     <property name="visible">True</property>
@@ -505,45 +505,14 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
+                    <property name="spacing">12</property>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkStack" id="download_images_wdg">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">12</property>
+                        <property name="transition-type">slide-up-down</property>
                         <child>
-                          <object class="GtkStack" id="download_images_wdg">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="transition-type">slide-up-down</property>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="HdyClamp">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="maximum-size">300</property>
-                            <child>
-                              <object class="GtkProgressBar" id="download_progress_wdg">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -569,7 +538,26 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="pack-type">end</property>
                         <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="HdyClamp">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="maximum-size">250</property>
+                        <child>
+                          <object class="GtkProgressBar" id="download_progress_wdg">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                   </object>

--- a/src/window.ui
+++ b/src/window.ui
@@ -477,6 +477,7 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
               <object class="GtkBox" id="download_page">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="valign">center</property>
                 <property name="vexpand">True</property>
                 <property name="border-width">18</property>
                 <property name="orientation">vertical</property>
@@ -485,6 +486,7 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                   <object class="GtkLabel" id="download_title_wdg">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="halign">center</property>
                     <property name="label">Downloading: XXX</property>
                     <property name="ellipsize">end</property>
                     <property name="xalign">0</property>
@@ -499,30 +501,50 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkStack" id="download_images_wdg">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="transition-type">slide-up-down</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkProgressBar" id="download_progress_wdg">
+                      <object class="GtkBox">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkStack" id="download_images_wdg">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="transition-type">slide-up-down</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="HdyClamp">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="maximum-size">300</property>
+                            <child>
+                              <object class="GtkProgressBar" id="download_progress_wdg">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -534,18 +556,16 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                       <object class="GtkLabel" id="download_info_wdg">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="halign">center</property>
                         <property name="label">Info XXX</property>
                         <property name="xalign">0</property>
-                        <accessibility>
-                          <relation type="label-for" target="download_progress_wdg"/>
-                        </accessibility>
                         <style>
                           <class name="dim-label"/>
                         </style>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">True</property>
+                        <property name="fill">False</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -782,6 +802,7 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
               <object class="GtkBox" id="success_page">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="valign">center</property>
                 <property name="vexpand">True</property>
                 <property name="border-width">18</property>
                 <property name="orientation">vertical</property>


### PR DESCRIPTION
Just minor changes :)
* center the box in downloading page
* center the box in finished downloading page
* use hdyclamp to limit the length of the progressbar

![Screenshot from 2021-03-29 12-44-13](https://user-images.githubusercontent.com/64297935/112788044-91bf8100-908c-11eb-992f-e5de77c920a4.png)
![Screenshot from 2021-03-29 12-57-39](https://user-images.githubusercontent.com/64297935/112788978-a0a73300-908e-11eb-839e-6d39960c9660.png)
