### PR TITLE
Set input-purpose to url

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -257,6 +257,7 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                                 <property name="hexpand">True</property>
                                 <property name="activates-default">True</property>
                                 <property name="input-hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
+                                <property name="input-purpose">url</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -342,6 +343,7 @@ along with Video Downloader.  If not, see <http://www.gnu.org/licenses/>.
                                 <property name="hexpand">True</property>
                                 <property name="activates-default">True</property>
                                 <property name="input-hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
+                                <property name="input-purpose">url</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>


### PR DESCRIPTION
Sets `GTK_INPUT_PURPOSE_URL` which is described as "Edited field expects URL".
https://docs.gtk.org/gtk3/enum.InputPurpose.html