### PR TITLE
Run download process in separate sandbox (Flatpak)

### DIFF
--- a/src/downloader/yt_dlp_slave.py
+++ b/src/downloader/yt_dlp_slave.py
@@ -430,7 +430,6 @@ class YoutubeDLSlave:
                 temp_download_dir = os.path.join(
                     download_dir, output_title + '.part')
                 try:
-                    os.makedirs(download_dir, exist_ok=True)
                     os.makedirs(temp_download_dir, exist_ok=True)
                 except OSError as e:
                     traceback.print_exc(file=sys.stderr)

--- a/src/model.py
+++ b/src/model.py
@@ -128,7 +128,15 @@ class Model(GObject.GObject, downloader.HandlerInterface):
         elif state == 'download':
             assert self._prev_state == 'start'
             self.finished_download_dir = expand_path(self.download_folder)
-            self._downloader.start()
+            try:
+                os.makedirs(self.finished_download_dir, exist_ok=True)
+            except OSError as e:
+                g_log(None, GLib.LogLevelFlags.LEVEL_CRITICAL,
+                      '%s', traceback.format_exc())
+                self.error = 'ERROR: Failed to create download folder: %s' % e
+                self.state = 'error'
+            else:
+                self._downloader.start()
         elif state == 'cancel':
             assert self._prev_state == 'download'
             self._downloader.cancel()


### PR DESCRIPTION
Allow the download process to access only the Internet and the download folder.
This is incompatible with #152 because the document portal is not accessible from inside restricted the sandbox.