### PR TITLE
Appdata related changes

### DIFF
--- a/data/com.github.unrud.VideoDownloader.metainfo.xml.in
+++ b/data/com.github.unrud.VideoDownloader.metainfo.xml.in
@@ -25,7 +25,7 @@
   <url type="bugtracker">https://github.com/Unrud/video-downloader/issues</url>
   <url type="homepage">https://github.com/Unrud/video-downloader</url>
   <url type="translate">https://hosted.weblate.org/engage/video-downloader/</url>
-  <developer_name translatable="no">Unrud</developer_name>
+  <developer_name translate="no">Unrud</developer_name>
   <update_contact>unrud_AT_outlook.com</update_contact>
   <translation type="gettext">video-downloader</translation>
   <screenshots>

--- a/data/com.github.unrud.VideoDownloader.metainfo.xml.in
+++ b/data/com.github.unrud.VideoDownloader.metainfo.xml.in
@@ -24,6 +24,7 @@
   <launchable type="desktop-id">com.github.unrud.VideoDownloader.desktop</launchable>
   <url type="bugtracker">https://github.com/Unrud/video-downloader/issues</url>
   <url type="homepage">https://github.com/Unrud/video-downloader</url>
+  <url type="vcs-browser">https://github.com/Unrud/video-downloader</url>
   <url type="translate">https://hosted.weblate.org/engage/video-downloader/</url>
   <developer_name translate="no">Unrud</developer_name>
   <developer id="io.github.unrud">

--- a/data/com.github.unrud.VideoDownloader.metainfo.xml.in
+++ b/data/com.github.unrud.VideoDownloader.metainfo.xml.in
@@ -26,6 +26,9 @@
   <url type="homepage">https://github.com/Unrud/video-downloader</url>
   <url type="translate">https://hosted.weblate.org/engage/video-downloader/</url>
   <developer_name translate="no">Unrud</developer_name>
+  <developer id="io.github.unrud">
+    <name translate="no">Unrud</name>
+  </developer>
   <update_contact>unrud_AT_outlook.com</update_contact>
   <translation type="gettext">video-downloader</translation>
   <screenshots>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer

### appdata: Add vcs-browser URL

Add vcs-browser URL to point the source code repository.